### PR TITLE
fix(docker): Update Dockerfile for standard build process

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,53 +1,47 @@
-# Builder stage
+# Builder stage: Install all dependencies, copy source, build the app
 FROM node:22.11.0-slim AS builder
-
 WORKDIR /app
+
+# Copy package files first for better caching
+COPY package.json yarn.lock ./
+
+# Install ALL dependencies (including devDependencies needed for build)
+RUN yarn install --frozen-lockfile
+
+# Copy the rest of the source code
+COPY . .
+
+# Build the Next.js app (includes prisma generate)
+RUN yarn build
+
+# Production stage: Install only production dependencies, copy build artifacts
+FROM node:22.11.0-slim AS production
+WORKDIR /usr/src/app
 
 # Copy package files
 COPY package.json yarn.lock ./
 
-# Install dependencies
-RUN yarn install --frozen-lockfile
+# Install ONLY production dependencies
+RUN yarn install --production --frozen-lockfile
 
-# Copy the source code
-COPY . .
+# Copy necessary artifacts from the builder stage
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+# Copy Prisma client generated during build and schema files
+COPY --from=builder /app/node_modules/.prisma ./node_modules/.prisma
+COPY --from=builder /app/prisma ./prisma
 
-# Prisma client generation is handled by the 'yarn build' script below
-# Build Next.js app
-RUN yarn build
-
-# Set up standalone Next.js output
-RUN cp -rf public .next/standalone/public && \
-    cp -rf .next/static .next/standalone/.next/static && \
-    mkdir -p .next/standalone/.prisma && \
-    cp -rf node_modules/.prisma/client .next/standalone/.prisma/ && \
-    cp -rf prisma .next/standalone/prisma && \
-    find .next/standalone -name "libquery_engine-*" -exec chmod +x {} \; || true && \
-    ls -la .next/standalone/.prisma/client/
-
-# Production stage
-FROM node:22.11.0-slim AS production
-
-WORKDIR /usr/src/app
-
-# Copy built app from builder stage
-COPY --from=builder /app/.next/standalone /usr/src/app
-COPY --from=builder /app/.next/static /usr/src/app/.next/static
-COPY --from=builder /app/public /usr/src/app/public
-# Copy Prisma client and schema files prepared in the standalone output
-COPY --from=builder /app/.next/standalone/.prisma /usr/src/app/.prisma
-COPY --from=builder /app/prisma /usr/src/app/prisma
-
-# Install production dependencies
+# Install runtime dependencies (like OpenSSL for Prisma) and ensure Prisma engines are executable
 RUN apt-get update && apt-get install -y openssl ca-certificates && \
-    chmod -R +x /usr/src/app/.prisma/client && \
-    ls -la /usr/src/app/.prisma/client/
+    find ./node_modules/.prisma/client -name "libquery_engine-*" -exec chmod +x {} \; || true && \
+    rm -rf /var/lib/apt/lists/*
 
-# Set environment variables
+# Set environment variables for production
 ENV NODE_ENV=production \
-    PORT=3000 \
-    DEBUG=prisma:*
+    PORT=3000
 
+# Expose the port the app runs on
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+# Start the app using the standard Next.js start script
+CMD ["yarn", "start"]

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  // output: "standalone", // Removed standalone output mode
+  // output: "standalone", // Reverted: Keep standalone output disabled due to Prisma issues
   experimental: {
     nodeMiddleware: true,
   },

--- a/web/package.json
+++ b/web/package.json
@@ -103,6 +103,7 @@
     "@types/react-dom": "19.0.4",
     "@typescript-eslint/eslint-plugin": "^8.27.0",
     "@typescript-eslint/parser": "^8.27.0",
+    "autoprefixer": "^10.4.21",
     "cross-env": "7.0.3",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2613,6 +2613,18 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
+autoprefixer@^10.4.21:
+  version "10.4.21"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.21.tgz#77189468e7a8ad1d9a37fbc08efc9f480cf0a95d"
+  integrity sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==
+  dependencies:
+    browserslist "^4.24.4"
+    caniuse-lite "^1.0.30001702"
+    fraction.js "^4.3.7"
+    normalize-range "^0.1.2"
+    picocolors "^1.1.1"
+    postcss-value-parser "^4.2.0"
+
 available-typed-arrays@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
@@ -2676,7 +2688,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0:
+browserslist@^4.24.0, browserslist@^4.24.4:
   version "4.24.4"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.4.tgz#c6b2865a3f08bcb860a0e827389003b9fe686e4b"
   integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
@@ -2747,7 +2759,7 @@ caniuse-lite@^1.0.30001579:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001706.tgz#902c3f896f4b2968031c3a546ab2ef8b465a2c8f"
   integrity sha512-3ZczoTApMAZwPKYWmwVbQMFpXBDds3/0VciVoUwPUbldlYyVLmRVuRs/PcUZtHpbLRpzzDvrvnFuREsGt6lUug==
 
-caniuse-lite@^1.0.30001688:
+caniuse-lite@^1.0.30001688, caniuse-lite@^1.0.30001702:
   version "1.0.30001713"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz#6b33a8857e6c7dcb41a0caa2dd0f0489c823a52d"
   integrity sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==
@@ -3846,6 +3858,11 @@ fp-ts@2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.16.0.tgz#64e03314dfc1c7ce5e975d3496ac14bc3eb7f92e"
   integrity sha512-bLq+KgbiXdTEoT1zcARrWEpa5z6A/8b7PcDW7Gef3NSisQ+VS7ll2Xbf1E+xsgik0rWub/8u0qP/iTTjj+PhxQ==
+
+fraction.js@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
+  integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
 fs-constants@^1.0.0:
   version "1.0.0"
@@ -5132,6 +5149,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+normalize-range@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+  integrity sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==
+
 npm-bundled@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-2.0.1.tgz#94113f7eb342cd7a67de1e789f896b04d2c600f4"
@@ -5509,7 +5531,7 @@ postcss-selector-parser@^6.1.1, postcss-selector-parser@^6.1.2:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^4.0.0:
+postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -6809,10 +6831,10 @@ typed-array-length@^1.0.7:
     possible-typed-array-names "^1.0.0"
     reflect.getprototypeof "^1.0.6"
 
-typescript@^5.8.2:
-  version "5.8.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
-  integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
+typescript@5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.3.tgz#e1b0a3c394190838a0b168e771b0ad56a0af0faa"
+  integrity sha512-/hreyEujaB0w76zKo6717l3L0o/qEUtRgdvUBvlkhoWeOVMjMuHNHk0BRBzikzuGDqNmPQbg5ifMEqsHLiIUcQ==
 
 unbox-primitive@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Updates the Dockerfile to use a standard Next.js build instead of standalone output. Adds missing autoprefixer dependency and updates yarn.lock. Reverts next.config.mjs to disable standalone output.