### PR TITLE
Test

### DIFF
--- a/web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsx
+++ b/web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsx
@@ -91,6 +91,13 @@ export default async function Page(
     ]
 
     const activeGroups = groups.filter(group => group.status === "Active")
+    const activeGroupsUserResponses = activeGroups.flatMap(
+      group => group.assessmentUser
+    ).flatMap(
+      user => user.user.assessmentUserResponse
+    ).filter(
+      response => response.attributeId === params.attributeId
+    )
     const partParticipants = assessmentUsers.filter(
       assessmentUser =>
         assessmentUser.role === "Participant" ||
@@ -135,7 +142,7 @@ export default async function Page(
               {params.roleName === "Facilitator" &&
                 <AttributeResponseTable
                   assessmentStatus={assessment.status}
-                  userResponses={userResponses}
+                  userResponses={activeGroups.length > 0 ? activeGroupsUserResponses : userResponses}
                   levels={levels}
                   numParticipants={numParticipants}
                 />

--- a/web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsx
+++ b/web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsx
@@ -9,6 +9,7 @@ import {
   fetchAssessmentAttribute,
   fetchAssessmentType,
   fetchAssessmentUsers,
+  fetchAssessmentUserGroups,
   fetchLevels,
   fetchNextAttribute,
   fetchPart,
@@ -55,6 +56,7 @@ export default async function Page(
   const levels = await fetchLevels(params.attributeId)
 
   const assessmentUsers = await fetchAssessmentUsers(params.assessmentId)
+  const groups = await fetchAssessmentUserGroups(params.assessmentId)
   const isParticipant = params.roleName === "Participant"
   const allResponses = await viewableResponses(
     session,
@@ -88,6 +90,7 @@ export default async function Page(
       },
     ]
 
+    const activeGroups = groups.filter(group => group.status === "Active")
     const partParticipants = assessmentUsers.filter(
       assessmentUser =>
         assessmentUser.role === "Participant" ||
@@ -95,6 +98,10 @@ export default async function Page(
           participantPart => participantPart.partId === part.id
         )
     )
+    const numParticipants =
+      activeGroups.length > 0 ?
+        activeGroups.flatMap(group => group.assessmentUser).length :
+        partParticipants.length
 
     const attributeIdDisplay =
       part.attributeType === "Attribute" ?
@@ -130,7 +137,7 @@ export default async function Page(
                   assessmentStatus={assessment.status}
                   userResponses={userResponses}
                   levels={levels}
-                  numParticipants={partParticipants.length}
+                  numParticipants={numParticipants}
                 />
               }
               <Card className="bg-white max-h-60 overflow-auto px-6 py-1">

--- a/web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/review-all-responses/sections.tsx
+++ b/web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/review-all-responses/sections.tsx
@@ -71,7 +71,7 @@ export default function Sections({
                 <AccordionContent className="flex flex-col space-y-4 px-4 pt-4 bg-white dark:bg-indigo-600/20 group-last:rounded-b-lg [&_div:last-child]:border-0 [&_div:last-child]:pb-0">
                   <DataTable
                     part={part}
-                    urlHead={`${assessmentTypeId}/assessments/${assessmentId}/${part.name}/${section.id}`}
+                    urlHead={`${assessmentTypeId}/assessments/${assessmentId}/Participant/${part.name}/${section.id}`}
                     attributes={sectionAttributesInAssessment}
                     userResponses={userResponses}
                   />


### PR DESCRIPTION
This pull request introduces functionality to handle active user groups in assessments and updates the logic for displaying participant data. The most significant changes include fetching and processing active groups, modifying the participant count logic, and updating the `AttributeResponseTable` and `DataTable` components to reflect these changes.

### Active Group Handling and Participant Logic Updates:

* `web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsx`:
  - Added `fetchAssessmentUserGroups` to retrieve user groups associated with the assessment. ([web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsxR12](diffhunk://#diff-75773d61f641108d6b0e6e27066ba6d4de3d031e677b92cc72d53f32939e1bf4R12))
  - Introduced logic to filter active groups and extract user responses specific to the current attribute. ([web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsxR93-R111](diffhunk://#diff-75773d61f641108d6b0e6e27066ba6d4de3d031e677b92cc72d53f32939e1bf4R93-R111))
  - Updated the participant count logic to account for active groups when calculating the number of participants. ([web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsxR93-R111](diffhunk://#diff-75773d61f641108d6b0e6e27066ba6d4de3d031e677b92cc72d53f32939e1bf4R93-R111))
  - Modified the `AttributeResponseTable` to use active group user responses and the updated participant count if active groups are present. ([web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsxL131-R147](diffhunk://#diff-75773d61f641108d6b0e6e27066ba6d4de3d031e677b92cc72d53f32939e1bf4L131-R147))

### UI Update for Review All Responses:

* `web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/review-all-responses/sections.tsx`:
  - Adjusted the `urlHead` in the `DataTable` component to include the `Participant` role in the path for consistency. ([web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/review-all-responses/sections.tsxL74-R74](diffhunk://#diff-14233861ab5ecd37b79d1a0d39f8dd37a921bd65da0f581edfd687e0df01efe4L74-R74))