### PR TITLE
fix: Active group user responses

### DIFF
--- a/web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsx
+++ b/web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsx
@@ -96,7 +96,9 @@ export default async function Page(
     ).flatMap(
       user => user.user.assessmentUserResponse
     ).filter(
-      response => response.attributeId === params.attributeId
+      response => response.attributeId ===
+        params.attributeId &&
+        response.assessmentId === assessment.id
     )
     const partParticipants = assessmentUsers.filter(
       assessmentUser =>


### PR DESCRIPTION
This pull request introduces enhancements to the data-fetching logic and filtering criteria for assessments and their related entities. The most significant changes include refining the filtering of user responses, enriching the data structure for assessment attributes and user groups, and adding a new function to fetch individual assessment parts.

### Filtering Enhancements:
* Refined the filtering logic in `page.tsx` to include both `attributeId` and `assessmentId` when processing user responses. This ensures more precise filtering based on the current assessment context. ([web/app/(frontend)/(logged-in)/[assessmentGroupId]/assessments/[assessmentId]/[roleName]/[partName]/[sectionId]/[attributeId]/page.tsxL99-R101](diffhunk://#diff-75773d61f641108d6b0e6e27066ba6d4de3d031e677b92cc72d53f32939e1bf4L99-R101))

### Data Structure Improvements:
* Updated `fetchAssessment` in `dataFetchers.ts` to include nested `levels` within `assessmentAttributes`, providing a richer data structure for attributes. [[1]](diffhunk://#diff-ae020d790ef5bd5781b62aac770033b1c0bdc86da71e97590ab2fe58ae96be2cL135-R138) [[2]](diffhunk://#diff-ae020d790ef5bd5781b62aac770033b1c0bdc86da71e97590ab2fe58ae96be2cL148-R151)
* Enhanced the structure of `fetchAssessmentUserGroups` to include `assessmentUserResponse` with nested `user` and `level` data, offering more detailed user response information. [[1]](diffhunk://#diff-ae020d790ef5bd5781b62aac770033b1c0bdc86da71e97590ab2fe58ae96be2cL157-R164) [[2]](diffhunk://#diff-ae020d790ef5bd5781b62aac770033b1c0bdc86da71e97590ab2fe58ae96be2cL169-R186)

### New Functionality:
* Added `fetchAssessmentPart` to retrieve a specific assessment part based on `assessmentId` and `partId`, improving flexibility in fetching individual parts.